### PR TITLE
[ObjC] Mark NSObject init / new as unavailable for records with any fields

### DIFF
--- a/example/generated-src/objc/TXSItemList.h
+++ b/example/generated-src/objc/TXSItemList.h
@@ -4,8 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface TXSItemList : NSObject
-- (nonnull instancetype)initWithItems:(nonnull NSArray<NSString *> *)items;
-+ (nonnull instancetype)itemListWithItems:(nonnull NSArray<NSString *> *)items;
+-(instancetype) init NS_UNAVAILABLE;
+- (nonnull instancetype)initWithItems:(nonnull NSArray<NSString *> *)items NS_DESIGNATED_INITIALIZER;
++ (nonnull instancetype)itemListWithItems:(nonnull NSArray<NSString *> *)items NS_DESIGNATED_INITIALIZER;
 
 @property (nonatomic, readonly, nonnull) NSArray<NSString *> * items;
 

--- a/src/source/ObjcGenerator.scala
+++ b/src/source/ObjcGenerator.scala
@@ -177,7 +177,19 @@ class ObjcGenerator(spec: Spec) extends BaseObjcGenerator(spec) {
       def writeInitializer(sign: String, prefix: String) {
         val decl = s"$sign (nonnull instancetype)$prefix$firstInitializerArg"
         writeAlignedObjcCall(w, decl, r.fields, "", f => (idObjc.field(f.ident), s"(${marshal.paramType(f.ty)})${idObjc.local(f.ident)}"))
-        w.wl(";")
+
+        if (prefix == "init") {
+          w.wl(" NS_DESIGNATED_INITIALIZER;")
+        } else {
+          w.wl(";")
+        }
+      }
+
+      if (r.fields.nonEmpty) {
+          // NSObject init / new are marked unavailable. Only allow designated initializer
+          // as records may have non-optional / nonnull fields.
+          w.wl("- (nonnull instancetype)init NS_UNAVAILABLE;")
+          w.wl("+ (nonnull instancetype)new NS_UNAVAILABLE;")
       }
 
       writeInitializer("-", "init")

--- a/test-suite/generated-src/objc/DBAssortedPrimitives.h
+++ b/test-suite/generated-src/objc/DBAssortedPrimitives.h
@@ -4,6 +4,8 @@
 #import <Foundation/Foundation.h>
 
 @interface DBAssortedPrimitives : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithB:(BOOL)b
                             eight:(int8_t)eight
                           sixteen:(int16_t)sixteen
@@ -17,7 +19,7 @@
                        oThirtytwo:(nullable NSNumber *)oThirtytwo
                        oSixtyfour:(nullable NSNumber *)oSixtyfour
                       oFthirtytwo:(nullable NSNumber *)oFthirtytwo
-                      oFsixtyfour:(nullable NSNumber *)oFsixtyfour;
+                      oFsixtyfour:(nullable NSNumber *)oFsixtyfour NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)assortedPrimitivesWithB:(BOOL)b
                                           eight:(int8_t)eight
                                         sixteen:(int16_t)sixteen

--- a/test-suite/generated-src/objc/DBClientReturnedRecord.h
+++ b/test-suite/generated-src/objc/DBClientReturnedRecord.h
@@ -5,9 +5,11 @@
 
 /** Record returned by a client */
 @interface DBClientReturnedRecord : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithRecordId:(int64_t)recordId
                                  content:(nonnull NSString *)content
-                                    misc:(nullable NSString *)misc;
+                                    misc:(nullable NSString *)misc NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)clientReturnedRecordWithRecordId:(int64_t)recordId
                                                  content:(nonnull NSString *)content
                                                     misc:(nullable NSString *)misc;

--- a/test-suite/generated-src/objc/DBConstantRecord.h
+++ b/test-suite/generated-src/objc/DBConstantRecord.h
@@ -5,8 +5,10 @@
 
 /** Record for use in constants */
 @interface DBConstantRecord : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithSomeInteger:(int32_t)someInteger
-                                 someString:(nonnull NSString *)someString;
+                                 someString:(nonnull NSString *)someString NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)constantRecordWithSomeInteger:(int32_t)someInteger
                                            someString:(nonnull NSString *)someString;
 

--- a/test-suite/generated-src/objc/DBConstantWithEnum.h
+++ b/test-suite/generated-src/objc/DBConstantWithEnum.h
@@ -6,7 +6,7 @@
 
 /** Record containing enum constant */
 @interface DBConstantWithEnum : NSObject
-- (nonnull instancetype)init;
+- (nonnull instancetype)init NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)constantWithEnum;
 
 + (DBConstantEnum)constEnum;

--- a/test-suite/generated-src/objc/DBConstants.h
+++ b/test-suite/generated-src/objc/DBConstants.h
@@ -6,7 +6,7 @@
 
 /** Record containing constants */
 @interface DBConstants : NSObject
-- (nonnull instancetype)init;
+- (nonnull instancetype)init NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)constants;
 
 + (NSNumber * __nullable)optBoolConstant;

--- a/test-suite/generated-src/objc/DBDateRecord.h
+++ b/test-suite/generated-src/objc/DBDateRecord.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBDateRecord : NSObject
-- (nonnull instancetype)initWithCreatedAt:(nonnull NSDate *)createdAt;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithCreatedAt:(nonnull NSDate *)createdAt NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)dateRecordWithCreatedAt:(nonnull NSDate *)createdAt;
 
 @property (nonatomic, readonly, nonnull) NSDate * createdAt;

--- a/test-suite/generated-src/objc/DBEmptyRecord.h
+++ b/test-suite/generated-src/objc/DBEmptyRecord.h
@@ -9,7 +9,7 @@
  *   Indented third line of multi-line documentation.)
  */
 @interface DBEmptyRecord : NSObject
-- (nonnull instancetype)init;
+- (nonnull instancetype)init NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)emptyRecord;
 
 @end

--- a/test-suite/generated-src/objc/DBEnumUsageRecord.h
+++ b/test-suite/generated-src/objc/DBEnumUsageRecord.h
@@ -5,11 +5,13 @@
 #import <Foundation/Foundation.h>
 
 @interface DBEnumUsageRecord : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithE:(DBColor)e
                                 o:(nullable NSNumber *)o
                                 l:(nonnull NSArray<NSNumber *> *)l
                                 s:(nonnull NSSet<NSNumber *> *)s
-                                m:(nonnull NSDictionary<NSNumber *, NSNumber *> *)m;
+                                m:(nonnull NSDictionary<NSNumber *, NSNumber *> *)m NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)enumUsageRecordWithE:(DBColor)e
                                            o:(nullable NSNumber *)o
                                            l:(nonnull NSArray<NSNumber *> *)l

--- a/test-suite/generated-src/objc/DBExtendedRecord.h
+++ b/test-suite/generated-src/objc/DBExtendedRecord.h
@@ -6,7 +6,9 @@
 
 /** Extended record */
 @interface DBExtendedRecord : NSObject
-- (nonnull instancetype)initWithFoo:(BOOL)foo;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithFoo:(BOOL)foo NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)extendedRecordWithFoo:(BOOL)foo;
 
 + (DBExtendedRecord * __nonnull)extendedRecordConst;

--- a/test-suite/generated-src/objc/DBExternRecordWithDerivings.h
+++ b/test-suite/generated-src/objc/DBExternRecordWithDerivings.h
@@ -7,8 +7,10 @@
 
 /** This file tests YAML dumped by Djinni can be parsed back in */
 @interface DBExternRecordWithDerivings : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithMember:(nonnull DBRecordWithDerivings *)member
-                                     e:(DBColor)e;
+                                     e:(DBColor)e NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)externRecordWithDerivingsWithMember:(nonnull DBRecordWithDerivings *)member
                                                           e:(DBColor)e;
 

--- a/test-suite/generated-src/objc/DBMapDateRecord.h
+++ b/test-suite/generated-src/objc/DBMapDateRecord.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBMapDateRecord : NSObject
-- (nonnull instancetype)initWithDatesById:(nonnull NSDictionary<NSString *, NSDate *> *)datesById;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithDatesById:(nonnull NSDictionary<NSString *, NSDate *> *)datesById NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)mapDateRecordWithDatesById:(nonnull NSDictionary<NSString *, NSDate *> *)datesById;
 
 @property (nonatomic, readonly, nonnull) NSDictionary<NSString *, NSDate *> * datesById;

--- a/test-suite/generated-src/objc/DBMapListRecord.h
+++ b/test-suite/generated-src/objc/DBMapListRecord.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBMapListRecord : NSObject
-- (nonnull instancetype)initWithMapList:(nonnull NSArray<NSDictionary<NSString *, NSNumber *> *> *)mapList;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithMapList:(nonnull NSArray<NSDictionary<NSString *, NSNumber *> *> *)mapList NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)mapListRecordWithMapList:(nonnull NSArray<NSDictionary<NSString *, NSNumber *> *> *)mapList;
 
 @property (nonatomic, readonly, nonnull) NSArray<NSDictionary<NSString *, NSNumber *> *> * mapList;

--- a/test-suite/generated-src/objc/DBMapRecord.h
+++ b/test-suite/generated-src/objc/DBMapRecord.h
@@ -4,8 +4,10 @@
 #import <Foundation/Foundation.h>
 
 @interface DBMapRecord : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithMap:(nonnull NSDictionary<NSString *, NSNumber *> *)map
-                               imap:(nonnull NSDictionary<NSNumber *, NSNumber *> *)imap;
+                               imap:(nonnull NSDictionary<NSNumber *, NSNumber *> *)imap NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)mapRecordWithMap:(nonnull NSDictionary<NSString *, NSNumber *> *)map
                                     imap:(nonnull NSDictionary<NSNumber *, NSNumber *> *)imap;
 

--- a/test-suite/generated-src/objc/DBNestedCollection.h
+++ b/test-suite/generated-src/objc/DBNestedCollection.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBNestedCollection : NSObject
-- (nonnull instancetype)initWithSetList:(nonnull NSArray<NSSet<NSString *> *> *)setList;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithSetList:(nonnull NSArray<NSSet<NSString *> *> *)setList NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)nestedCollectionWithSetList:(nonnull NSArray<NSSet<NSString *> *> *)setList;
 
 @property (nonatomic, readonly, nonnull) NSArray<NSSet<NSString *> *> * setList;

--- a/test-suite/generated-src/objc/DBParcelableList.h
+++ b/test-suite/generated-src/objc/DBParcelableList.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBParcelableList : NSObject
-- (nonnull instancetype)initWithL:(nonnull NSArray<NSString *> *)l;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithL:(nonnull NSArray<NSString *> *)l NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)parcelableListWithL:(nonnull NSArray<NSString *> *)l;
 
 @property (nonatomic, readonly, nonnull) NSArray<NSString *> * l;

--- a/test-suite/generated-src/objc/DBParcelableListMapSet.h
+++ b/test-suite/generated-src/objc/DBParcelableListMapSet.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBParcelableListMapSet : NSObject
-- (nonnull instancetype)initWithListMapSet:(nonnull NSArray<NSDictionary<NSString *, NSSet<NSString *> *> *> *)listMapSet;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithListMapSet:(nonnull NSArray<NSDictionary<NSString *, NSSet<NSString *> *> *> *)listMapSet NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)parcelableListMapSetWithListMapSet:(nonnull NSArray<NSDictionary<NSString *, NSSet<NSString *> *> *> *)listMapSet;
 
 @property (nonatomic, readonly, nonnull) NSArray<NSDictionary<NSString *, NSSet<NSString *> *> *> * listMapSet;

--- a/test-suite/generated-src/objc/DBParcelableListSet.h
+++ b/test-suite/generated-src/objc/DBParcelableListSet.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBParcelableListSet : NSObject
-- (nonnull instancetype)initWithListSet:(nonnull NSArray<NSSet<NSString *> *> *)listSet;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithListSet:(nonnull NSArray<NSSet<NSString *> *> *)listSet NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)parcelableListSetWithListSet:(nonnull NSArray<NSSet<NSString *> *> *)listSet;
 
 @property (nonatomic, readonly, nonnull) NSArray<NSSet<NSString *> *> * listSet;

--- a/test-suite/generated-src/objc/DBParcelableMap.h
+++ b/test-suite/generated-src/objc/DBParcelableMap.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBParcelableMap : NSObject
-- (nonnull instancetype)initWithM:(nonnull NSDictionary<NSString *, NSString *> *)m;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithM:(nonnull NSDictionary<NSString *, NSString *> *)m NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)parcelableMapWithM:(nonnull NSDictionary<NSString *, NSString *> *)m;
 
 @property (nonatomic, readonly, nonnull) NSDictionary<NSString *, NSString *> * m;

--- a/test-suite/generated-src/objc/DBParcelableMapList.h
+++ b/test-suite/generated-src/objc/DBParcelableMapList.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBParcelableMapList : NSObject
-- (nonnull instancetype)initWithMapSet:(nonnull NSDictionary<NSString *, NSArray<NSString *> *> *)mapSet;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithMapSet:(nonnull NSDictionary<NSString *, NSArray<NSString *> *> *)mapSet NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)parcelableMapListWithMapSet:(nonnull NSDictionary<NSString *, NSArray<NSString *> *> *)mapSet;
 
 @property (nonatomic, readonly, nonnull) NSDictionary<NSString *, NSArray<NSString *> *> * mapSet;

--- a/test-suite/generated-src/objc/DBParcelableMapSet.h
+++ b/test-suite/generated-src/objc/DBParcelableMapSet.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBParcelableMapSet : NSObject
-- (nonnull instancetype)initWithMapSet:(nonnull NSDictionary<NSString *, NSSet<NSString *> *> *)mapSet;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithMapSet:(nonnull NSDictionary<NSString *, NSSet<NSString *> *> *)mapSet NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)parcelableMapSetWithMapSet:(nonnull NSDictionary<NSString *, NSSet<NSString *> *> *)mapSet;
 
 @property (nonatomic, readonly, nonnull) NSDictionary<NSString *, NSSet<NSString *> *> * mapSet;

--- a/test-suite/generated-src/objc/DBParcelableOptionalList.h
+++ b/test-suite/generated-src/objc/DBParcelableOptionalList.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBParcelableOptionalList : NSObject
-- (nonnull instancetype)initWithOptionalSet:(nullable NSArray<NSString *> *)optionalSet;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithOptionalSet:(nullable NSArray<NSString *> *)optionalSet NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)parcelableOptionalListWithOptionalSet:(nullable NSArray<NSString *> *)optionalSet;
 
 @property (nonatomic, readonly, nullable) NSArray<NSString *> * optionalSet;

--- a/test-suite/generated-src/objc/DBParcelableOptionalMap.h
+++ b/test-suite/generated-src/objc/DBParcelableOptionalMap.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBParcelableOptionalMap : NSObject
-- (nonnull instancetype)initWithOptionalSet:(nullable NSDictionary<NSString *, NSSet<NSString *> *> *)optionalSet;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithOptionalSet:(nullable NSDictionary<NSString *, NSSet<NSString *> *> *)optionalSet NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)parcelableOptionalMapWithOptionalSet:(nullable NSDictionary<NSString *, NSSet<NSString *> *> *)optionalSet;
 
 @property (nonatomic, readonly, nullable) NSDictionary<NSString *, NSSet<NSString *> *> * optionalSet;

--- a/test-suite/generated-src/objc/DBParcelableOptionalSet.h
+++ b/test-suite/generated-src/objc/DBParcelableOptionalSet.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBParcelableOptionalSet : NSObject
-- (nonnull instancetype)initWithOptionalSet:(nullable NSSet<NSString *> *)optionalSet;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithOptionalSet:(nullable NSSet<NSString *> *)optionalSet NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)parcelableOptionalSetWithOptionalSet:(nullable NSSet<NSString *> *)optionalSet;
 
 @property (nonatomic, readonly, nullable) NSSet<NSString *> * optionalSet;

--- a/test-suite/generated-src/objc/DBParcelablePrimitives.h
+++ b/test-suite/generated-src/objc/DBParcelablePrimitives.h
@@ -4,6 +4,8 @@
 #import <Foundation/Foundation.h>
 
 @interface DBParcelablePrimitives : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithB:(BOOL)b
                             eight:(int8_t)eight
                           sixteen:(int16_t)sixteen
@@ -21,7 +23,7 @@
                       oFthirtytwo:(nullable NSNumber *)oFthirtytwo
                       oFsixtyfour:(nullable NSNumber *)oFsixtyfour
                                oS:(nullable NSString *)oS
-                               oD:(nullable NSDate *)oD;
+                               oD:(nullable NSDate *)oD NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)parcelablePrimitivesWithB:(BOOL)b
                                             eight:(int8_t)eight
                                           sixteen:(int16_t)sixteen

--- a/test-suite/generated-src/objc/DBParcelableSet.h
+++ b/test-suite/generated-src/objc/DBParcelableSet.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBParcelableSet : NSObject
-- (nonnull instancetype)initWithSet:(nonnull NSSet<NSString *> *)set;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithSet:(nonnull NSSet<NSString *> *)set NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)parcelableSetWithSet:(nonnull NSSet<NSString *> *)set;
 
 @property (nonatomic, readonly, nonnull) NSSet<NSString *> * set;

--- a/test-suite/generated-src/objc/DBPrimitiveList.h
+++ b/test-suite/generated-src/objc/DBPrimitiveList.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBPrimitiveList : NSObject
-- (nonnull instancetype)initWithList:(nonnull NSArray<NSNumber *> *)list;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithList:(nonnull NSArray<NSNumber *> *)list NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)primitiveListWithList:(nonnull NSArray<NSNumber *> *)list;
 
 @property (nonatomic, readonly, nonnull) NSArray<NSNumber *> * list;

--- a/test-suite/generated-src/objc/DBRecordUsingExtendedRecord.h
+++ b/test-suite/generated-src/objc/DBRecordUsingExtendedRecord.h
@@ -6,7 +6,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBRecordUsingExtendedRecord : NSObject
-- (nonnull instancetype)initWithEr:(nonnull DBExtendedRecord *)er;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithEr:(nonnull DBExtendedRecord *)er NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)recordUsingExtendedRecordWithEr:(nonnull DBExtendedRecord *)er;
 
 + (DBRecordUsingExtendedRecord * __nonnull)cr;

--- a/test-suite/generated-src/objc/DBRecordWithDerivings.h
+++ b/test-suite/generated-src/objc/DBRecordWithDerivings.h
@@ -4,6 +4,8 @@
 #import <Foundation/Foundation.h>
 
 @interface DBRecordWithDerivings : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithEight:(int8_t)eight
                               sixteen:(int16_t)sixteen
                             thirtytwo:(int32_t)thirtytwo
@@ -11,7 +13,7 @@
                            fthirtytwo:(float)fthirtytwo
                            fsixtyfour:(double)fsixtyfour
                                     d:(nonnull NSDate *)d
-                                    s:(nonnull NSString *)s;
+                                    s:(nonnull NSString *)s NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)recordWithDerivingsWithEight:(int8_t)eight
                                              sixteen:(int16_t)sixteen
                                            thirtytwo:(int32_t)thirtytwo

--- a/test-suite/generated-src/objc/DBRecordWithDurationAndDerivings.h
+++ b/test-suite/generated-src/objc/DBRecordWithDurationAndDerivings.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBRecordWithDurationAndDerivings : NSObject
-- (nonnull instancetype)initWithDt:(NSTimeInterval)dt;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithDt:(NSTimeInterval)dt NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)recordWithDurationAndDerivingsWithDt:(NSTimeInterval)dt;
 
 @property (nonatomic, readonly) NSTimeInterval dt;

--- a/test-suite/generated-src/objc/DBRecordWithFlags.h
+++ b/test-suite/generated-src/objc/DBRecordWithFlags.h
@@ -5,7 +5,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBRecordWithFlags : NSObject
-- (nonnull instancetype)initWithAccess:(DBAccessFlags)access;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithAccess:(DBAccessFlags)access NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)recordWithFlagsWithAccess:(DBAccessFlags)access;
 
 @property (nonatomic, readonly) DBAccessFlags access;

--- a/test-suite/generated-src/objc/DBRecordWithNestedDerivings.h
+++ b/test-suite/generated-src/objc/DBRecordWithNestedDerivings.h
@@ -5,8 +5,10 @@
 #import <Foundation/Foundation.h>
 
 @interface DBRecordWithNestedDerivings : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithKey:(int32_t)key
-                                rec:(nonnull DBRecordWithDerivings *)rec;
+                                rec:(nonnull DBRecordWithDerivings *)rec NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)recordWithNestedDerivingsWithKey:(int32_t)key
                                                      rec:(nonnull DBRecordWithDerivings *)rec;
 

--- a/test-suite/generated-src/objc/DBSetRecord.h
+++ b/test-suite/generated-src/objc/DBSetRecord.h
@@ -4,8 +4,10 @@
 #import <Foundation/Foundation.h>
 
 @interface DBSetRecord : NSObject
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
 - (nonnull instancetype)initWithSet:(nonnull NSSet<NSString *> *)set
-                               iset:(nonnull NSSet<NSNumber *> *)iset;
+                               iset:(nonnull NSSet<NSNumber *> *)iset NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)setRecordWithSet:(nonnull NSSet<NSString *> *)set
                                     iset:(nonnull NSSet<NSNumber *> *)iset;
 

--- a/test-suite/generated-src/objc/DBTestOptionalExternInterfaceRecord.h
+++ b/test-suite/generated-src/objc/DBTestOptionalExternInterfaceRecord.h
@@ -5,7 +5,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBTestOptionalExternInterfaceRecord : NSObject
-- (nonnull instancetype)initWithSampleInterface:(nullable DBSampleInterface *)sampleInterface;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithSampleInterface:(nullable DBSampleInterface *)sampleInterface NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)testOptionalExternInterfaceRecordWithSampleInterface:(nullable DBSampleInterface *)sampleInterface;
 
 @property (nonatomic, readonly, nullable) DBSampleInterface * sampleInterface;

--- a/test-suite/generated-src/objc/DBVarnameRecord.h
+++ b/test-suite/generated-src/objc/DBVarnameRecord.h
@@ -9,7 +9,9 @@
  * badly when it is.  However this test case ensures we at least don't crash.
  */
 @interface DBVarnameRecord : NSObject
-- (nonnull instancetype)initWithField:(int8_t)Field;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithField:(int8_t)Field NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)VarnameRecordWithField:(int8_t)Field;
 
 @property (nonatomic, readonly) int8_t Field;

--- a/test-suite/generated-src/objc/DBWcharTestRec.h
+++ b/test-suite/generated-src/objc/DBWcharTestRec.h
@@ -4,7 +4,9 @@
 #import <Foundation/Foundation.h>
 
 @interface DBWcharTestRec : NSObject
-- (nonnull instancetype)initWithS:(nonnull NSString *)s;
+- (nonnull instancetype)init NS_UNAVAILABLE;
++ (nonnull instancetype)new NS_UNAVAILABLE;
+- (nonnull instancetype)initWithS:(nonnull NSString *)s NS_DESIGNATED_INITIALIZER;
 + (nonnull instancetype)wcharTestRecWithS:(nonnull NSString *)s;
 
 @property (nonatomic, readonly, nonnull) NSString * s;


### PR DESCRIPTION
- Records with non-null fields will be improperly constructed if a default initializer (`[NSObject init]`) is called, which can cause an unexpectedly unwrapped optional `nil` in Swift code. Mark these as unavailable to hide them from Swift. 